### PR TITLE
Fix badge links for moved repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![PyPI version](https://img.shields.io/pypi/v/fpp-sle)](https://pypi.org/project/fpp-sle/)
 [![Python version](https://img.shields.io/pypi/pyversions/fpp-sle)](https://pypi.org/project/fpp-sle/)
 [![Licence](https://img.shields.io/badge/license-GPL3-yellow)](https://opensource.org/licenses/GPL-3.0)
-[![Tests](https://github.com/engeir/fpp-sle/workflows/Tests/badge.svg)](https://github.com/engeir/fpp-sle/actions?workflow=Tests)
-[![codecov](https://codecov.io/gh/engeir/fpp-sle/branch/main/graph/badge.svg?token=F98z2i3T4G)](https://codecov.io/gh/engeir/fpp-sle)
+[![Tests](https://github.com/uit-cosmo/fpp-sle/workflows/Tests/badge.svg)](https://github.com/uit-cosmo/fpp-sle/actions?workflow=Tests)
+[![codecov](https://codecov.io/gh/uit-cosmo/fpp-sle/branch/main/graph/badge.svg?token=F98z2i3T4G)](https://codecov.io/gh/uit-cosmo/fpp-sle)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
Codecov link was broken after moving the repo from engeir to uit-cosmo organization.