### PR TITLE
fix(docs): clone link was to the old owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To contribute to the project, clone and install the full development version (us
 [poetry] for dependencies):
 
 ```sh
-git clone https://github.com/engeir/fpp-sle
+git clone https://github.com/uit-cosmo/fpp-sle.git
 cd fpp-sle
 poetry install
 pre-commit install


### PR DESCRIPTION
This was the old clone link from when @engeir owned the repo.